### PR TITLE
Suppress warnings about events without "emit"

### DIFF
--- a/sol/tests.sol.js
+++ b/sol/tests.sol.js
@@ -10,93 +10,93 @@ library Assert {
 
   function ok(bool a, string message) public returns (bool result) {
     result = a;
-    AssertionEvent(result, message);
+    emit AssertionEvent(result, message);
   }
 
   function equal(uint a, uint b, string message) public returns (bool result) {
     result = (a == b);
-    AssertionEvent(result, message);
+    emit AssertionEvent(result, message);
   }
 
   function equal(int a, int b, string message) public returns (bool result) {
     result = (a == b);
-    AssertionEvent(result, message);
+    emit AssertionEvent(result, message);
   }
 
   function equal(bool a, bool b, string message) public returns (bool result) {
     result = (a == b);
-    AssertionEvent(result, message);
+    emit AssertionEvent(result, message);
   }
 
   // TODO: only for certain versions of solc
   //function equal(fixed a, fixed b, string message) public returns (bool result) {
   //  result = (a == b);
-  //  AssertionEvent(result, message);
+  //  emit AssertionEvent(result, message);
   //}
 
   // TODO: only for certain versions of solc
   //function equal(ufixed a, ufixed b, string message) public returns (bool result) {
   //  result = (a == b);
-  //  AssertionEvent(result, message);
+  //  emit AssertionEvent(result, message);
   //}
 
   function equal(address a, address b, string message) public returns (bool result) {
     result = (a == b);
-    AssertionEvent(result, message);
+    emit AssertionEvent(result, message);
   }
 
   function equal(bytes32 a, bytes32 b, string message) public returns (bool result) {
     result = (a == b);
-    AssertionEvent(result, message);
+    emit AssertionEvent(result, message);
   }
 
   // TODO: needs to be convert to bytes first to be comparable
   //function equal(string a, string b, string message) public returns (bool result) {
   //  result = (a == b);
-  //  AssertionEvent(result, message);
+  //  emit AssertionEvent(result, message);
   //}
 
   function notEqual(uint a, uint b, string message) public returns (bool result) {
     result = (a != b);
-    AssertionEvent(result, message);
+    emit AssertionEvent(result, message);
   }
 
   function notEqual(int a, int b, string message) public returns (bool result) {
     result = (a != b);
-    AssertionEvent(result, message);
+    emit AssertionEvent(result, message);
   }
 
   function notEqual(bool a, bool b, string message) public returns (bool result) {
     result = (a != b);
-    AssertionEvent(result, message);
+    emit AssertionEvent(result, message);
   }
 
   // TODO: only for certain versions of solc
   //function notEqual(fixed a, fixed b, string message) public returns (bool result) {
   //  result = (a != b);
-  //  AssertionEvent(result, message);
+  //  emit AssertionEvent(result, message);
   //}
 
   // TODO: only for certain versions of solc
   //function notEqual(ufixed a, ufixed b, string message) public returns (bool result) {
   //  result = (a != b);
-  //  AssertionEvent(result, message);
+  //  emit AssertionEvent(result, message);
   //}
 
   function notEqual(address a, address b, string message) public returns (bool result) {
     result = (a != b);
-    AssertionEvent(result, message);
+    emit AssertionEvent(result, message);
   }
 
   function notEqual(bytes32 a, bytes32 b, string message) public returns (bool result) {
     result = (a != b);
-    AssertionEvent(result, message);
+    emit AssertionEvent(result, message);
   }
 
   // TODO: needs to be convert to bytes first to be comparable
   //function notEqual(string a, string b, string message) public returns (bool result) {
   //  result = (a != b);
-  //  AssertionEvent(result, message);
+  //  emit AssertionEvent(result, message);
   //}
 
 }


### PR DESCRIPTION
When I first start the Remix IDE, the following warnings are shown in the Compile tab.

```
remix_tests.sol:13:5: Warning: Invoking events without "emit" prefix is deprecated.
    AssertionEvent(result, message);
    ^-----------------------------^
```

To avoid this, add `emit` in front.